### PR TITLE
Empty Song Cell Support (Aka, Null Discs)

### DIFF
--- a/src/custom_song_creator.cpp
+++ b/src/custom_song_creator.cpp
@@ -3500,16 +3500,14 @@ void custom_song_creator_update(size_t width, size_t height) {
 				else {
 					tabName += "Unknown";
 				}
-				if (gCtx.currentPak->root.saveCelAsNull[celSlotIdx]) {
-					tabName += " (Null)";
-				}
+
 				tabName += "##Cel" + std::to_string(celSlotIdx);
 
 				if (ImGui::BeginTabItem(tabName.c_str())) {
 					curCelTab = static_cast<int>(celSlotIdx * 2);
 					bool wasNull = gCtx.currentPak->root.saveCelAsNull[celSlotIdx];
 					bool saveAsNullCheckboxValue = wasNull;
-					std::string checkboxLabel = "Save this channel as null##SaveCellAsNull" + std::to_string(celSlotIdx);
+					std::string checkboxLabel = "Save this channel as empty##SaveCellAsNull" + std::to_string(celSlotIdx);
 					if (ImGui::Checkbox(checkboxLabel.c_str(), &saveAsNullCheckboxValue)) {
 						gCtx.currentPak->root.saveCelAsNull[celSlotIdx] = saveAsNullCheckboxValue;
 						if (wasNull != saveAsNullCheckboxValue) {
@@ -3518,12 +3516,12 @@ void custom_song_creator_update(size_t width, size_t height) {
 					}
 
 					if (gCtx.currentPak->root.saveCelAsNull[celSlotIdx]) {
-						ImGui::TextDisabled("This slot will be hidden in-game by saving root Cels[%d] as null.", (int)celSlotIdx);
+						ImGui::TextDisabled("This slot will be hidden in-game by saving root Cels[%d] as empty.", (int)celSlotIdx);
 						if (celData != nullptr) {
 							ImGui::TextDisabled("The cel data was found and will stay editable/preserved.");
 						}
 						else {
-							ImGui::TextDisabled("No preserved cel asset was found for this null slot.");
+							ImGui::TextDisabled("No preserved cel asset was found for this empty slot.");
 						}
 					}
 
@@ -3531,7 +3529,7 @@ void custom_song_creator_update(size_t width, size_t height) {
 						display_cel_data(*celData, gCtx.currentPak->root.keyMode);
 					}
 					else {
-						ImGui::TextDisabled("This null slot has no recoverable editor data in the loaded pak.");
+						ImGui::TextDisabled("This empty slot has no recoverable editor data in the loaded pak.");
 					}
 					ImGui::EndTabItem();
 				}

--- a/src/custom_song_creator.cpp
+++ b/src/custom_song_creator.cpp
@@ -438,6 +438,7 @@ void load_file(DataBuffer&& dataBuf) {
 		FuserEnums::KeyMode::Value keyMode = gCtx.currentPak->root.keyMode;
 		FuserEnums::Genre::Value genre = gCtx.currentPak->root.genre;
 		i32 year = gCtx.currentPak->root.year;
+		std::vector<bool> saveCelAsNull = gCtx.currentPak->root.saveCelAsNull;
 		std::vector<HmxAudio::PackageFile> celFusionPackageFile;
 		std::vector<std::vector<HmxAudio::PackageFile>> celMoggFiles;
 		std::vector<std::string> instrumentTypes;
@@ -478,9 +479,16 @@ void load_file(DataBuffer&& dataBuf) {
 		gCtx.currentPak->root.keyMode = keyMode;
 		gCtx.currentPak->root.genre = genre;
 		gCtx.currentPak->root.year = year;
+		gCtx.currentPak->root.saveCelAsNull = saveCelAsNull;
+		if (gCtx.currentPak->root.saveCelAsNull.size() < gCtx.currentPak->root.celData.size()) {
+			gCtx.currentPak->root.saveCelAsNull.resize(gCtx.currentPak->root.celData.size(), false);
+		}
 
 		int idx = 0;
 		for (auto& cel : gCtx.currentPak->root.celData) {
+			if (idx >= celShortName.size()) {
+				break;
+			}
 			
 			cel.data.shortName = celShortName[idx];
 			auto&& fusionFile = cel.data.majorAssets[0].data.fusionFile.data;
@@ -606,7 +614,13 @@ void write_sig(DataBuffer outBuf, std::string outPath) {
 	std::ofstream outPak(outPath, std::ios_base::binary);
 	outPak.write((char*)sigOutBuf.buffer, sigOutBuf.size);
 }
+bool Error_FullyBlankNullCel = false;
 void save_file() {
+	if (gCtx.currentPak != nullptr && gCtx.currentPak->root.wouldSaveFullyBlankSong()) {
+		Error_FullyBlankNullCel = true;
+		return;
+	}
+
 	SongSerializationCtx ctx;
 	ctx.loading = false;
 	ctx.pak = &gCtx.currentPak->pak;
@@ -3452,19 +3466,75 @@ void custom_song_creator_update(size_t width, size_t height) {
 				ImGui::EndChild();
 				ImGui::EndTabItem();
 			}
-			int idx = 0;
-			for (auto&& cel : gCtx.currentPak->root.celData) {
-				cel.data.clampBPM = !fcsc_cfg.disableClamping;
-				cel.data.songTransitionFile.data.clampBPM = !fcsc_cfg.disableClamping;
-				std::string tabName = "Song Cell " + std::to_string(idx / 2) + " - ";
-				tabName += cel.data.type.getString();
-				tabName += "##Cel" + std::to_string(idx / 2);
+			const char* slotNames[] = { "Beat", "Bass", "Loop", "Lead" };
+			size_t slotCount = gCtx.currentPak->root.saveCelAsNull.size();
+			if (slotCount < 4) {
+				slotCount = 4;
+			}
+			if (gCtx.currentPak->root.celDataIndexForSlot.size() < slotCount) {
+				gCtx.currentPak->root.celDataIndexForSlot.resize(slotCount, static_cast<size_t>(-1));
+			}
+			if (gCtx.currentPak->root.saveCelAsNull.size() < slotCount) {
+				gCtx.currentPak->root.saveCelAsNull.resize(slotCount, false);
+			}
+
+			for (size_t celSlotIdx = 0; celSlotIdx < slotCount; ++celSlotIdx) {
+				size_t dataIdx = gCtx.currentPak->root.celDataIndexForSlot[celSlotIdx];
+				CelData* celData = nullptr;
+				if (dataIdx != static_cast<size_t>(-1) && dataIdx < gCtx.currentPak->root.celData.size()) {
+					celData = &gCtx.currentPak->root.celData[dataIdx].data;
+				}
+
+				if (celData != nullptr) {
+					celData->clampBPM = !fcsc_cfg.disableClamping;
+					celData->songTransitionFile.data.clampBPM = !fcsc_cfg.disableClamping;
+				}
+
+				std::string tabName = "Song Cell " + std::to_string(celSlotIdx) + " - ";
+				if (celData != nullptr) {
+					tabName += celData->type.getString();
+				}
+				else if (celSlotIdx < 4) {
+					tabName += slotNames[celSlotIdx];
+				}
+				else {
+					tabName += "Unknown";
+				}
+				if (gCtx.currentPak->root.saveCelAsNull[celSlotIdx]) {
+					tabName += " (Null)";
+				}
+				tabName += "##Cel" + std::to_string(celSlotIdx);
+
 				if (ImGui::BeginTabItem(tabName.c_str())) {
-					curCelTab = idx;
-					display_cel_data(cel.data, gCtx.currentPak->root.keyMode);
+					curCelTab = static_cast<int>(celSlotIdx * 2);
+					bool wasNull = gCtx.currentPak->root.saveCelAsNull[celSlotIdx];
+					bool saveAsNullCheckboxValue = wasNull;
+					std::string checkboxLabel = "Save this channel as null##SaveCellAsNull" + std::to_string(celSlotIdx);
+					if (ImGui::Checkbox(checkboxLabel.c_str(), &saveAsNullCheckboxValue)) {
+						gCtx.currentPak->root.saveCelAsNull[celSlotIdx] = saveAsNullCheckboxValue;
+						if (wasNull != saveAsNullCheckboxValue) {
+							unsavedChanges = true;
+						}
+					}
+
+					if (gCtx.currentPak->root.saveCelAsNull[celSlotIdx]) {
+						ImGui::TextDisabled("This slot will be hidden in-game by saving root Cels[%d] as null.", (int)celSlotIdx);
+						if (celData != nullptr) {
+							ImGui::TextDisabled("The cel data was found and will stay editable/preserved.");
+						}
+						else {
+							ImGui::TextDisabled("No preserved cel asset was found for this null slot.");
+						}
+					}
+
+					if (celData != nullptr) {
+						display_cel_data(*celData, gCtx.currentPak->root.keyMode);
+					}
+					else {
+						ImGui::TextDisabled("This null slot has no recoverable editor data in the loaded pak.");
+					}
 					ImGui::EndTabItem();
 				}
-				idx += 2;
 			}
 
 			ImGui::EndTabBar();
@@ -3474,9 +3544,14 @@ void custom_song_creator_update(size_t width, size_t height) {
 			ImGui::OpenPopup("Invalid File Name");
 			Error_InvalidFileName = false;
 		}
+		if (Error_FullyBlankNullCel) {
+			ImGui::OpenPopup("Cannot Save Fully Blank Song");
+			Error_FullyBlankNullCel = false;
+		}
 		auto fileName = gCtx.currentPak->root.shortName + "_P.pak";
 		auto error = "Your file must be named as " + fileName + ", otherwise the song loader won't unlock it!";
 		ErrorModal("Invalid File Name", error.c_str());
+		ErrorModal("Cannot Save Fully Blank Song", "Cannot save a fully blank song. At least one song cell must remain enabled.");
 	}
 	else {
 		ImGui::Text("Welcome to the Fuser Custom Song Creator!");

--- a/src/fuser_asset.h
+++ b/src/fuser_asset.h
@@ -1082,9 +1082,58 @@ struct AssetRoot {
 	SongPakEntry file;
 
 	std::vector<FileLink<CelData>> celData;
+	std::vector<bool> saveCelAsNull;
+	std::vector<size_t> celDataIndexForSlot;
+	std::vector<i64> celLinkValForSlot;
 	std::vector<FileLink<Texture2D>> textureData;
 	AssetLink<IconFileAsset> small_icon_link;
 	AssetLink<IconFileAsset> large_icon_link;
+
+	static CelType::Type celTypeForSlot(size_t slotIdx) {
+		switch (slotIdx) {
+		case 0: return CelType::Type::Beat;
+		case 1: return CelType::Type::Bass;
+		case 2: return CelType::Type::Loop;
+		case 3: return CelType::Type::Lead;
+		default: return CelType::Type::Beat;
+		}
+	}
+
+	static i64 findRootCelLinkValForAssetPath(SongSerializationCtx &ctx, const std::string &assetPathWithoutExtension) {
+		auto &&header = ctx.getHeader();
+		const std::string fullAssetPath = Game_Prefix + assetPathWithoutExtension;
+
+		for (size_t linkIdx = 0; linkIdx < header.links.size(); ++linkIdx) {
+			i64 candidateLinkVal = -static_cast<i64>(linkIdx) - 1;
+			auto &&candidateRef = header.getLinkRef(candidateLinkVal);
+			if (candidateRef.link == 0) {
+				continue;
+			}
+
+			auto &&linkedFile = header.getLinkRef(candidateRef.link);
+			if (header.getHeaderRef(linkedFile.property) == fullAssetPath) {
+				return candidateLinkVal;
+			}
+		}
+
+		return 0;
+	}
+
+	bool wouldSaveFullyBlankSong() const {
+		if (saveCelAsNull.empty()) {
+			return false;
+		}
+
+		bool hasEnabledSlot = false;
+		for (bool saveNull : saveCelAsNull) {
+			if (!saveNull) {
+				hasEnabledSlot = true;
+				break;
+			}
+		}
+
+		return !hasEnabledSlot;
+	}
 
 	void serialize(SongSerializationCtx &ctx) {
 		ctx.shortName = shortName;
@@ -1127,12 +1176,45 @@ struct AssetRoot {
 			icon = ctx.getProp<SoftObjectProperty>(file.e, "SongIconImage_Large");
 			large_icon_link.ref = icon->name;
 			large_icon_link.serialize(ctx);
-			auto &celArray = *ctx.getProp<ArrayProperty>(file.e, "Cels");
-			for (auto &&v : celArray.values) {
-				FileLink<CelData> fileLink;
-				fileLink.linkVal = std::get<ObjectProperty>(v->v).linkVal;
-				fileLink.serialize(ctx);
+			celData.clear();
+			saveCelAsNull.clear();
+			celDataIndexForSlot.clear();
+			celLinkValForSlot.clear();
 
+			auto &celArray = *ctx.getProp<ArrayProperty>(file.e, "Cels");
+			for (size_t celSlotIdx = 0; celSlotIdx < celArray.values.size(); ++celSlotIdx) {
+				auto &&v = celArray.values[celSlotIdx];
+				i64 rootLinkVal = std::get<ObjectProperty>(v->v).linkVal;
+				bool slotIsNull = (rootLinkVal == 0);
+				saveCelAsNull.emplace_back(slotIsNull);
+				celDataIndexForSlot.emplace_back(static_cast<size_t>(-1));
+				celLinkValForSlot.emplace_back(rootLinkVal);
+
+				FileLink<CelData> fileLink;
+				fileLink.linkVal = rootLinkVal;
+
+				if (!slotIsNull) {
+					fileLink.serialize(ctx);
+				}
+				else {
+					CelType inferredType;
+					inferredType.value = celTypeForSlot(celSlotIdx);
+					std::string celAssetName = inferredType.suffix(ctx.shortName);
+					std::string celAssetPath = ctx.folderRoot() + celAssetName + "/Meta_" + celAssetName;
+					auto recoveredCelEntry = ctx.getFile(celAssetPath + ".uexp");
+
+					if (recoveredCelEntry != nullptr) {
+						fileLink.linkVal = findRootCelLinkValForAssetPath(ctx, celAssetPath);
+						celLinkValForSlot[celSlotIdx] = fileLink.linkVal;
+						auto prevFile = ctx.curEntry;
+						ctx.curEntry = recoveredCelEntry;
+						fileLink.data.file.e = recoveredCelEntry;
+						fileLink.data.serialize(ctx);
+						ctx.curEntry = prevFile;
+					}
+				}
+
+				if (fileLink.data.file.e != nullptr) {
 					ctx.songName = songName = ctx.getProp<TextProperty>(fileLink.data.file.e, "Title")->strings.back();
 					ctx.bpm = bpm = ctx.getProp<PrimitiveProperty<i32>>(fileLink.data.file.e, "BPM")->data;
 					ctx.songKey = songKey = ctx.getProp<EnumProperty>(fileLink.data.file.e, "Key")->value.getString(fileLink.data.file.e->getHeader());
@@ -1143,7 +1225,9 @@ struct AssetRoot {
 					if (ctx.curKeyMode != FuserEnums::KeyMode::Value::Num) {
 						actualMode = ctx.curKeyMode;
 					}
-				celData.emplace_back(std::move(fileLink));
+					celDataIndexForSlot[celSlotIdx] = celData.size();
+					celData.emplace_back(std::move(fileLink));
+				}
 			}
 			ctx.songKey = songKey = actualKey;
 			ctx.curKeyMode = keyMode = actualMode;
@@ -1159,10 +1243,34 @@ struct AssetRoot {
 			auto streamOptimizedProp = ctx.getOrCreateProp<BoolProperty>("IsStreamOptimized");
 			streamOptimizedProp.prop->value = isStreamOptimized;
 
-			size_t idx = 0;
 			for (auto &&e : celData) {
-				e.serialize(ctx);
-				++idx;
+				if (e.linkVal != 0) {
+					e.serialize(ctx);
+				}
+			}
+
+			auto celArrayProp = ctx.getProp<ArrayProperty>(file.e, "Cels");
+			if (celArrayProp != nullptr) {
+				size_t maxSlots = celArrayProp->values.size();
+				if (saveCelAsNull.size() < maxSlots) {
+					maxSlots = saveCelAsNull.size();
+				}
+
+				for (size_t celSlotIdx = 0; celSlotIdx < maxSlots; ++celSlotIdx) {
+					auto &obj = std::get<ObjectProperty>(celArrayProp->values[celSlotIdx]->v);
+					if (saveCelAsNull[celSlotIdx]) {
+						obj.linkVal = 0;
+					}
+					else if (celSlotIdx < celLinkValForSlot.size() && celLinkValForSlot[celSlotIdx] != 0) {
+						obj.linkVal = celLinkValForSlot[celSlotIdx];
+					}
+					else if (celSlotIdx < celDataIndexForSlot.size() && celDataIndexForSlot[celSlotIdx] != static_cast<size_t>(-1)) {
+						size_t dataIdx = celDataIndexForSlot[celSlotIdx];
+						if (dataIdx < celData.size() && celData[dataIdx].linkVal != 0) {
+							obj.linkVal = celData[dataIdx].linkVal;
+						}
+					}
+				}
 			}
 		}
 	}

--- a/src/fuser_asset.h
+++ b/src/fuser_asset.h
@@ -731,9 +731,9 @@ struct SongTransition {
 
 			i32 bpm = ctx.bpm;
 			if (clampBPM) {
-				while (bpm > 157) bpm = std::ceil(bpm /= 2); //half-time anything faster, recursively
-				if (bpm < 90) bpm = ctx.bpm; //prevent 158-179 bpm from clamping to 90
-				bpm = std::clamp(bpm, 90, 157);
+				while (bpm > 200) bpm = std::ceil(bpm /= 2); //half-time anything faster, recursively
+				if (bpm < 60) bpm = ctx.bpm;
+				bpm = std::clamp(bpm, 60, 200);
 			}
 			ctx.serializePrimitive("BPM", bpm);
 
@@ -955,9 +955,9 @@ struct CelData {
 			
 			i32 bpm = ctx.bpm;
 			if (clampBPM) {
-				while (bpm > 157) bpm = std::ceil(bpm /= 2); //half-time anything faster, recursively
-				if (bpm < 90) bpm = ctx.bpm; //prevent 158-179 bpm from clamping to 90
-				bpm = std::clamp(bpm, 90, 157);
+				while (bpm > 200) bpm = std::ceil(bpm /= 2); //half-time anything faster, recursively
+				if (bpm < 60) bpm = ctx.bpm; 
+				bpm = std::clamp(bpm, 60, 200);
 			}
 			ctx.serializePrimitive("BPM", bpm);
 


### PR DESCRIPTION
## Summary

Adds round-trip support for **Empty song cells** / reduced-channel songs.

FUSER supports songs where entries in the root `CelSongSet.Cels` array are intentionally null. This allows a song to use fewer than four playable cells, such as a song with no Lead cell. This change exposes that behavior in the tool using frontend-friendly “Empty” wording while preserving the underlying cel data.

## What changed

- Added per-song-cell support for saving Beat/Bass/Loop/Lead slots as Empty
- Empty cells are written as null entries in the root `CelSongSet.Cels` array
- Existing cel data is preserved so Empty cells can be restored later
- Reopening a song with Empty cells detects the state correctly
- Empty cells can be toggled back on without losing the cell data
- Added validation to prevent accidentally saving a fully blank song
- Updated user-facing wording from “Null” to “Empty”

## Notes

This is not a destructive mute/delete operation. The selected cell is hidden from the game-facing song set by nulling the root cel reference, while the tool keeps the cell’s data available for editing and restoration.

Tested with custom songs in-game and confirmed reduced-channel layouts work.